### PR TITLE
add missing namespaces to resources

### DIFF
--- a/gitops/platform/charts/teams/templates/networkpolicy/egress/allow-dns.yaml
+++ b/gitops/platform/charts/teams/templates/networkpolicy/egress/allow-dns.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.networkPolicies.enabled) (.Values.networkPolicies.egress.allow.dns.enabled) }}
-{{- range .Values.namespaces }}
+{{- range $name, $tenant := .Values.namespaces }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -19,7 +19,7 @@ metadata:
     {{- end }}
     {{- end }}
   name: {{ include "team.networkPolicy.egress.allow.dns.name" $ | quote }}
-  namespace: {{ .name | quote }}
+  namespace: {{ $name }}
 spec:
   {{- if $.Values.networkPolicies.egress.allow.dns.podSelector }}
   podSelector:

--- a/gitops/platform/charts/teams/templates/networkpolicy/egress/deny-all.yaml
+++ b/gitops/platform/charts/teams/templates/networkpolicy/egress/deny-all.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.networkPolicies.enabled) (.Values.networkPolicies.egress.deny.all) }}
-{{- range .Values.namespaces }}
+{{- range $name, $tenant := .Values.namespaces }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -19,7 +19,7 @@ metadata:
     {{- end }}
     {{- end }}
   name: {{ include "team.networkPolicy.egress.deny.all.name" $ | quote }}
-  namespace: {{ .name | quote }}
+  namespace: {{ $name }}
 spec:
   {{- if $.Values.networkPolicies.egress.deny.all.podSelector }}
   podSelector:

--- a/gitops/platform/charts/teams/templates/networkpolicy/ingress/deny-all.yaml
+++ b/gitops/platform/charts/teams/templates/networkpolicy/ingress/deny-all.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.networkPolicies.enabled) (.Values.networkPolicies.ingress.deny.all) }}
-{{- range .Values.namespaces }}
+{{- range $name, $tenant := .Values.namespaces }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -19,7 +19,7 @@ metadata:
     {{- end }}
     {{- end }}
   name: {{ include "team.networkPolicy.ingress.deny.all.name" $ | quote }}
-  namespace: {{ .name | quote }}
+  namespace: {{ $name }}
 spec:
   {{- if $.Values.networkPolicies.ingress.deny.all.podSelector }}
   podSelector:

--- a/gitops/platform/charts/teams/templates/networkpolicy/networkpolicy.yaml
+++ b/gitops/platform/charts/teams/templates/networkpolicy/networkpolicy.yaml
@@ -1,10 +1,11 @@
-{{- range .Values.namespaces }}
-{{- range .networkPolicies }}
+{{- range $name, $tenant := .Values.namespaces }}
+{{- range $tenant.networkPolicies }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .name }}
+  namespace: {{ $name }}
   annotations:
     {{- include "team.annotations" $ | nindent 4 }}
     {{- if .annotations }}

--- a/gitops/platform/charts/teams/templates/rbac/role.yaml
+++ b/gitops/platform/charts/teams/templates/rbac/role.yaml
@@ -1,8 +1,8 @@
 {{- range $name, $tenant := .Values.namespaces }}
-{{- range $tenant.limitRanges }}
+{{- range $tenant.roles }}
 ---
-apiVersion: v1
-kind: LimitRange
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
   name: {{ .name }}
   namespace: {{ $name }}
@@ -20,8 +20,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- end }}
-spec:
-  limits:
-  {{- toYaml .limits | nindent 4}}
+rules:
+  {{- toYaml .rules | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/gitops/platform/charts/teams/templates/rbac/rolebinding.yaml
+++ b/gitops/platform/charts/teams/templates/rbac/rolebinding.yaml
@@ -1,8 +1,8 @@
 {{- range $name, $tenant := .Values.namespaces }}
-{{- range $tenant.limitRanges }}
+{{- range $tenant.roleBindings }}
 ---
-apiVersion: v1
-kind: LimitRange
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
   name: {{ .name }}
   namespace: {{ $name }}
@@ -20,8 +20,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- end }}
-spec:
-  limits:
-  {{- toYaml .limits | nindent 4}}
+subjects:
+  {{- toYaml .subjects | nindent 2 }}
+roleRef:
+  {{- toYaml .roleRef | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/gitops/platform/charts/teams/templates/resourcequota/resourcequota.yaml
+++ b/gitops/platform/charts/teams/templates/resourcequota/resourcequota.yaml
@@ -1,10 +1,11 @@
-{{- range .Values.namespaces }}
-{{- range .resourceQuotas }}
+{{- range $name, $tenant := .Values.namespaces }}
+{{- range $tenant.resourceQuotas }}
 ---
 apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: {{ .name }}
+  namespace: {{ $name }}
   annotations:
     {{- include "team.annotations" $ | nindent 4 }}
     {{- if .annotations }}


### PR DESCRIPTION
*Description of changes:*

The teams chart was missing the namespace for resources like networkpolicy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
