### PR TITLE
add name for argo AppProjects

### DIFF
--- a/gitops/platform/teams/backend/argoproject-values.yaml
+++ b/gitops/platform/teams/backend/argoproject-values.yaml
@@ -1,3 +1,4 @@
+name: backend
 argoProject:
   spec:
     destinations:

--- a/gitops/platform/teams/frontend/argoproject-values.yaml
+++ b/gitops/platform/teams/frontend/argoproject-values.yaml
@@ -1,45 +1,46 @@
+name: frontend
 argoProject:
   spec:
     destinations:
-    - namespace: ui
-      name: spoke-prod
-    - namespace: assets
-      name: spoke-prod
-    - namespace: ui
-      name: spoke-staging
-    - namespace: assets
-      name: spoke-staging
+      - namespace: ui
+        name: spoke-prod
+      - namespace: assets
+        name: spoke-prod
+      - namespace: ui
+        name: spoke-staging
+      - namespace: assets
+        name: spoke-staging
     # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
     namespaceResourceBlacklist:
-    - group: ''
-      kind: ResourceQuota
-    - group: ''
-      kind: LimitRange
-    - group: ''
-      kind: NetworkPolicy
+      - group: ''
+        kind: ResourceQuota
+      - group: ''
+        kind: LimitRange
+      - group: ''
+        kind: NetworkPolicy
     # Deny all namespaced-scoped resources from being created, except for these
     namespaceResourceWhitelist:
-    - group: ''
-      kind: Pod
-    - group: 'apps'
-      kind: Deployment
-    - group: 'apps'
-      kind: StatefulSet
-    - group: 'apps'
-      kind: ReplicaSet
-    - group: ''
-      kind: Service
-    - group: ''
-      kind: ServiceAccount
-    - group: ''
-      kind: ConfigMap
-    - group: ''
-      kind: Secret
-    - group: 'rbac.authorization.k8s.io'
-      kind: RoleBinding
-    - group: 'rbac.authorization.k8s.io'
-      kind: Role
-    - group: 'dynamodb.services.k8s.aws'
-      kind: Table
-    - group: 'autoscaling'
-      kind: HorizontalPodAutoscaler
+      - group: ''
+        kind: Pod
+      - group: 'apps'
+        kind: Deployment
+      - group: 'apps'
+        kind: StatefulSet
+      - group: 'apps'
+        kind: ReplicaSet
+      - group: ''
+        kind: Service
+      - group: ''
+        kind: ServiceAccount
+      - group: ''
+        kind: ConfigMap
+      - group: ''
+        kind: Secret
+      - group: 'rbac.authorization.k8s.io'
+        kind: RoleBinding
+      - group: 'rbac.authorization.k8s.io'
+        kind: Role
+      - group: 'dynamodb.services.k8s.aws'
+        kind: Table
+      - group: 'autoscaling'
+        kind: HorizontalPodAutoscaler


### PR DESCRIPTION
*Issue #, if available:*

Fix Issue where both frontend and backend argo AppProject resources where competing with the same default name

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
